### PR TITLE
Fix SpeedSolitaire embed viewport fit

### DIFF
--- a/src/data/games.json
+++ b/src/data/games.json
@@ -225,6 +225,7 @@
       }
     ],
     "fullScreenUrl": "/play/speedsolitaire/",
-    "embedUrl": "/play/speedsolitaire/"
+    "embedUrl": "/play/speedsolitaire/",
+    "embedOrientation": "portrait"
   }
 ]

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -14,6 +14,7 @@ export function getStaticPaths() {
 const { game, allGames } = Astro.props as { game: Game; allGames: Game[] };
 const showEmbed = Boolean(game.embedUrl);
 const showFullScreen = Boolean(game.fullScreenUrl);
+const isPortraitEmbed = game.embedOrientation === 'portrait';
 
 const fallbackIntro = `${game.title} is a browser game from Terapixel Games with quick sessions and accessible gameplay.`;
 const fallbackDetails =
@@ -81,7 +82,7 @@ const faqJsonLd =
       {
         showEmbed ? (
           <div class="player-wrap">
-            <div class="player-frame">
+            <div class:list={['player-frame', isPortraitEmbed && 'player-frame-portrait']}>
               <iframe
                 src={game.embedUrl as string}
                 title={`${game.title} game`}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -665,7 +665,13 @@ input {
 .player-frame {
   position: relative;
   width: 100%;
-  padding-top: 56.25%;
+  aspect-ratio: 16 / 9;
+}
+
+.player-frame-portrait {
+  aspect-ratio: 9 / 16;
+  max-width: min(100%, 460px);
+  margin-inline: auto;
 }
 
 .player-frame iframe {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,5 +15,6 @@ export type Game = {
   faq?: GameFaq[];
   fullScreenUrl: string | null;
   embedUrl: string | null;
+  embedOrientation?: 'landscape' | 'portrait';
   isComingSoon?: boolean;
 };


### PR DESCRIPTION
## Summary
- add optional `embedOrientation` metadata to games
- mark `speedsolitaire` as `portrait`
- switch game player frame to aspect-ratio based layout with a portrait variant
- apply portrait frame class on detail pages when game metadata requests it

## Validation
- `npm run build`