### PR TITLE
Switch SpeedSolitaire embed frame to landscape

### DIFF
--- a/src/data/games.json
+++ b/src/data/games.json
@@ -226,6 +226,6 @@
     ],
     "fullScreenUrl": "/play/speedsolitaire/",
     "embedUrl": "/play/speedsolitaire/",
-    "embedOrientation": "portrait"
+    "embedOrientation": "landscape"
   }
 ]


### PR DESCRIPTION
## Summary
- switch SpeedSolitaire embed orientation metadata to landscape
- remove portrait frame class application for this title

## Validation
- `npm run build`