### PR TITLE
Fix game detail links to resolve correctly in staging and prod

### DIFF
--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -12,11 +12,10 @@ export function getStaticPaths() {
 }
 
 const { game, allGames } = Astro.props as { game: Game; allGames: Game[] };
-const isStagingPath = Astro.url.pathname.startsWith('/staging/');
 const mapPlayableUrl = (value: string | null): string | null => {
   if (!value) return null;
-  if (isStagingPath && value.startsWith('/play/')) {
-    return `/staging${value}`;
+  if (value.startsWith('/play/')) {
+    return `../play/${value.slice('/play/'.length)}`;
   }
   return value;
 };


### PR DESCRIPTION
## Summary
- normalize game detail page playable links to relative paths
- transform `/play/...` to `../play/...` so both production and staging resolve correctly

## Validation
- `npm run build -- --base /staging/`