### PR TITLE
feat(analytics): add GA4 gtag to site layout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -51,7 +51,19 @@ const identityHydrateSessionOnLoad =
       href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Sora:wght@500;600;700&display=swap"
       rel="stylesheet"
     />
-    
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-L74E223LX0"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+
+      gtag('config', 'G-L74E223LX0');
+    </script>
+
     <script
       async
       src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8413230766502262"


### PR DESCRIPTION
## Summary
- add Google Analytics gtag.js loader globally in `BaseLayout.astro`
- initialize GA4 with measurement ID `G-L74E223LX0`

## Validation
- npm.cmd run build
- Deploy Staging run: https://github.com/Terapixel-Games/terapixel.games/actions/runs/22524687463
- Confirmed `gh-pages/staging/index.html` contains GA tag/config