### PR TITLE
fix: make staging links base-aware and cache-bust play embeds

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -33,6 +33,7 @@ jobs:
       PUBLIC_TPX_IDENTITY_EMAIL_PARAM: ${{ vars.PUBLIC_TPX_IDENTITY_EMAIL_PARAM }}
       PUBLIC_TPX_IDENTITY_LOGOUT_METHOD: ${{ vars.PUBLIC_TPX_IDENTITY_LOGOUT_METHOD }}
       PUBLIC_TPX_IDENTITY_HYDRATE_SESSION_ON_LOAD: ${{ vars.PUBLIC_TPX_IDENTITY_HYDRATE_SESSION_ON_LOAD }}
+      PUBLIC_TPX_BUILD_ID: ${{ github.sha }}
 
     steps:
       - name: Checkout
@@ -75,6 +76,7 @@ jobs:
             printf 'PUBLIC_TPX_IDENTITY_EMAIL_PARAM=%s\n' "${PUBLIC_TPX_IDENTITY_EMAIL_PARAM:-}"
             printf 'PUBLIC_TPX_IDENTITY_LOGOUT_METHOD=%s\n' "${PUBLIC_TPX_IDENTITY_LOGOUT_METHOD:-}"
             printf 'PUBLIC_TPX_IDENTITY_HYDRATE_SESSION_ON_LOAD=%s\n' "${PUBLIC_TPX_IDENTITY_HYDRATE_SESSION_ON_LOAD:-}"
+            printf 'PUBLIC_TPX_BUILD_ID=%s\n' "${PUBLIC_TPX_BUILD_ID:-}"
           } > .env.production
 
       - name: Deploy production static site to Cloud Run

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -38,6 +38,7 @@ jobs:
           PUBLIC_TPX_IDENTITY_EMAIL_PARAM: ${{ vars.PUBLIC_TPX_IDENTITY_EMAIL_PARAM }}
           PUBLIC_TPX_IDENTITY_LOGOUT_METHOD: ${{ vars.PUBLIC_TPX_IDENTITY_LOGOUT_METHOD }}
           PUBLIC_TPX_IDENTITY_HYDRATE_SESSION_ON_LOAD: ${{ vars.PUBLIC_TPX_IDENTITY_HYDRATE_SESSION_ON_LOAD }}
+          PUBLIC_TPX_BUILD_ID: ${{ github.sha }}
         run: npm run build -- --base /staging/
 
       - name: Deploy staging to gh-pages/staging

--- a/src/components/GameCard.astro
+++ b/src/components/GameCard.astro
@@ -1,5 +1,6 @@
 ---
 import type { Game } from '../types';
+import { addBuildVersion, withBasePath } from '../lib/site-paths';
 
 interface Props {
   game: Game;
@@ -7,9 +8,16 @@ interface Props {
 }
 
 const { game, playMode = 'detail' } = Astro.props;
-const detailHref = `/${game.slug}`;
+const buildVersion = import.meta.env.PUBLIC_TPX_BUILD_ID;
+const detailHref = withBasePath(`/${game.slug}`);
 const isPlayable = Boolean(game.embedUrl || game.fullScreenUrl) && !game.isComingSoon;
-const playHref = playMode === 'fullscreen' && game.fullScreenUrl ? game.fullScreenUrl : detailHref;
+const fallbackImage = withBasePath('/images/placeholder-game.svg');
+const gameImageSrc = game.image.startsWith('/') ? withBasePath(game.image) : game.image;
+const fullScreenPath =
+  game.fullScreenUrl && game.fullScreenUrl.startsWith('/')
+    ? addBuildVersion(withBasePath(game.fullScreenUrl), buildVersion)
+    : game.fullScreenUrl;
+const playHref = playMode === 'fullscreen' && fullScreenPath ? fullScreenPath : detailHref;
 const playTarget = playMode === 'fullscreen' && game.fullScreenUrl ? '_blank' : undefined;
 const playRel = playMode === 'fullscreen' && game.fullScreenUrl ? 'noreferrer noopener' : undefined;
 ---
@@ -19,22 +27,22 @@ const playRel = playMode === 'fullscreen' && game.fullScreenUrl ? 'noreferrer no
     isPlayable ? (
       <a href={detailHref} class="game-card-media-link">
         <img
-          src={game.image}
+          src={gameImageSrc}
           alt={game.title}
           class="game-card-media"
           loading="lazy"
-          onerror="this.onerror=null;this.src='/images/placeholder-game.svg';"
+          onerror={`this.onerror=null;this.src='${fallbackImage}';`}
         />
         <span class="game-card-overlay" aria-hidden="true"></span>
       </a>
     ) : (
       <div class="game-card-media-link">
         <img
-          src={game.image}
+          src={gameImageSrc}
           alt={game.title}
           class="game-card-media"
           loading="lazy"
-          onerror="this.onerror=null;this.src='/images/placeholder-game.svg';"
+          onerror={`this.onerror=null;this.src='${fallbackImage}';`}
         />
         <span class="game-card-overlay" aria-hidden="true"></span>
       </div>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,4 +1,6 @@
 ---
+import { withBasePath, withoutBasePath } from '../lib/site-paths';
+
 const { pathname = '/' } = Astro.props;
 
 const logoUrl =
@@ -12,7 +14,9 @@ const links = [
 ];
 
 const staticPaths = new Set(['/', '/games', '/shop', '/account', '/support', '/privacy-policy', '/contact']);
-const normalizedPath = pathname.endsWith('/') && pathname !== '/' ? pathname.slice(0, -1) : pathname;
+const baseRelativePath = withoutBasePath(pathname);
+const normalizedPath =
+  baseRelativePath.endsWith('/') && baseRelativePath !== '/' ? baseRelativePath.slice(0, -1) : baseRelativePath;
 const isGameDetail = /^\/[^/]+$/.test(normalizedPath) && !staticPaths.has(normalizedPath);
 const accountActive = normalizedPath === '/account';
 ---
@@ -20,7 +24,7 @@ const accountActive = normalizedPath === '/account';
 <header class="site-header">
   <div class="shell">
     <div class="topbar">
-      <a href="/" class="brand" aria-label="Terapixel Games Home">
+      <a href={withBasePath('/')} class="brand" aria-label="Terapixel Games Home">
         <img
           src={logoUrl}
           alt=""
@@ -43,7 +47,7 @@ const accountActive = normalizedPath === '/account';
               (link.href === '/games' && (normalizedPath === '/games' || isGameDetail));
             return (
               <li>
-                <a href={link.href} class="nav-link" aria-current={active ? 'page' : undefined}>
+                <a href={withBasePath(link.href)} class="nav-link" aria-current={active ? 'page' : undefined}>
                   {link.label}
                 </a>
               </li>
@@ -51,7 +55,7 @@ const accountActive = normalizedPath === '/account';
           })
         }
         <li id="tpx-account-nav" class="hidden">
-          <a href="/account" class="nav-link" aria-current={accountActive ? 'page' : undefined}>
+          <a href={withBasePath('/account')} class="nav-link" aria-current={accountActive ? 'page' : undefined}>
             Account
           </a>
         </li>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -9,6 +9,7 @@ interface ImportMetaEnv {
   readonly PUBLIC_TPX_IDENTITY_EMAIL_PARAM?: string;
   readonly PUBLIC_TPX_IDENTITY_LOGOUT_METHOD?: string;
   readonly PUBLIC_TPX_IDENTITY_HYDRATE_SESSION_ON_LOAD?: string;
+  readonly PUBLIC_TPX_BUILD_ID?: string;
 }
 
 interface ImportMeta {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css';
 import Nav from '../components/Nav.astro';
+import { withBasePath } from '../lib/site-paths';
 
 interface Props {
   title: string;
@@ -24,6 +25,11 @@ const identityEmailParam = import.meta.env.PUBLIC_TPX_IDENTITY_EMAIL_PARAM || 'e
 const identityLogoutMethod = import.meta.env.PUBLIC_TPX_IDENTITY_LOGOUT_METHOD || 'POST';
 const identityHydrateSessionOnLoad =
   import.meta.env.PUBLIC_TPX_IDENTITY_HYDRATE_SESSION_ON_LOAD || 'true';
+const faviconUrl = withBasePath('/favicon.svg');
+const identityScriptUrl = withBasePath('/scripts/terapixel-identity.js');
+const privacyPolicyUrl = withBasePath('/privacy-policy');
+const supportUrl = withBasePath('/support');
+const contactUrl = withBasePath('/contact');
 ---
 
 <!doctype html>
@@ -44,7 +50,7 @@ const identityHydrateSessionOnLoad =
     <meta name="twitter:title" content={socialTitle} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={imageHref} />
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href={faviconUrl} type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -80,7 +86,7 @@ const identityHydrateSessionOnLoad =
         hydrateFromSessionOnLoad: {JSON.stringify(identityHydrateSessionOnLoad)}
       };
     </script>
-    <script src="/scripts/terapixel-identity.js" defer></script>
+    <script src={identityScriptUrl} defer></script>
     <slot name="head" />
   </head>
   <body class="site-body">
@@ -93,9 +99,9 @@ const identityHydrateSessionOnLoad =
       <div class="shell footer-row">
         <p>&copy; {new Date().getFullYear()} Terapixel Games</p>
         <div class="footer-links">
-          <a href="/privacy-policy">Privacy Policy</a>
-          <a href="/support">Support</a>
-          <a href="/contact">Contact</a>
+          <a href={privacyPolicyUrl}>Privacy Policy</a>
+          <a href={supportUrl}>Support</a>
+          <a href={contactUrl}>Contact</a>
         </div>
       </div>
     </footer>

--- a/src/lib/site-paths.ts
+++ b/src/lib/site-paths.ts
@@ -1,0 +1,78 @@
+const rawBaseUrl = import.meta.env.BASE_URL || '/';
+const normalizedBasePath = rawBaseUrl === '/' ? '' : `/${rawBaseUrl.replace(/^\/+|\/+$/g, '')}`;
+
+const ABSOLUTE_URL_PATTERN = /^(?:[a-z][a-z0-9+.-]*:)?\/\//i;
+
+export const withBasePath = (path: string): string => {
+  if (!path) {
+    return normalizedBasePath || '/';
+  }
+
+  if (
+    ABSOLUTE_URL_PATTERN.test(path) ||
+    path.startsWith('mailto:') ||
+    path.startsWith('tel:') ||
+    path.startsWith('#') ||
+    path.startsWith('data:')
+  ) {
+    return path;
+  }
+
+  if (!path.startsWith('/')) {
+    return path;
+  }
+
+  if (!normalizedBasePath) {
+    return path;
+  }
+
+  if (path === normalizedBasePath || path.startsWith(`${normalizedBasePath}/`)) {
+    return path;
+  }
+
+  return `${normalizedBasePath}${path}`;
+};
+
+export const withoutBasePath = (pathname: string): string => {
+  if (!pathname) {
+    return '/';
+  }
+
+  if (!normalizedBasePath) {
+    return pathname;
+  }
+
+  if (pathname === normalizedBasePath) {
+    return '/';
+  }
+
+  if (pathname.startsWith(`${normalizedBasePath}/`)) {
+    return pathname.slice(normalizedBasePath.length) || '/';
+  }
+
+  return pathname;
+};
+
+export const addBuildVersion = (url: string, buildVersion: string | undefined): string => {
+  if (!url || !buildVersion) {
+    return url;
+  }
+
+  if (
+    url.startsWith('mailto:') ||
+    url.startsWith('tel:') ||
+    url.startsWith('#') ||
+    url.startsWith('data:')
+  ) {
+    return url;
+  }
+
+  try {
+    const parsed = new URL(url, 'https://terapixel.games');
+    parsed.searchParams.set('v', buildVersion);
+    const isAbsolute = ABSOLUTE_URL_PATTERN.test(url);
+    return isAbsolute ? parsed.toString() : `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return url;
+  }
+};

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import games from '../data/games.json';
 import type { Game } from '../types';
+import { addBuildVersion, withBasePath } from '../lib/site-paths';
 
 export function getStaticPaths() {
   const gameList = games as Game[];
@@ -12,10 +13,15 @@ export function getStaticPaths() {
 }
 
 const { game, allGames } = Astro.props as { game: Game; allGames: Game[] };
+const buildVersion = import.meta.env.PUBLIC_TPX_BUILD_ID;
 const mapPlayableUrl = (value: string | null): string | null => {
   if (!value) return null;
-  if (value.startsWith('/play/')) {
-    return `../play/${value.slice('/play/'.length)}`;
+  if (value.startsWith('/')) {
+    const baseAwareUrl = withBasePath(value);
+    if (value.startsWith('/play/')) {
+      return addBuildVersion(baseAwareUrl, buildVersion);
+    }
+    return baseAwareUrl;
   }
   return value;
 };
@@ -119,7 +125,7 @@ const faqJsonLd =
             <span class="chip muted">Fullscreen coming soon</span>
           )
         }
-        <a href="/games" class="btn btn-secondary">Back to Games</a>
+        <a href={withBasePath('/games')} class="btn btn-secondary">Back to Games</a>
       </div>
     </section>
 
@@ -165,7 +171,7 @@ const faqJsonLd =
           </h2>
           <div class="related-grid">
             {relatedGames.map((relatedGame) => (
-              <a href={`/${relatedGame.slug}`} class="related-link">
+              <a href={withBasePath(`/${relatedGame.slug}`)} class="related-link">
                 <strong>{relatedGame.title}</strong>
                 <span>View details</span>
               </a>

--- a/src/pages/account.astro
+++ b/src/pages/account.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { withBasePath } from '../lib/site-paths';
 ---
 
 <BaseLayout title="Account" description="Manage your Terapixel account profile, username, and support links.">
@@ -40,14 +41,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <h2>Store Access</h2>
         <p>Open curated packs and support options built for clarity.</p>
         <div class="hero-actions">
-          <a href="/shop" class="btn btn-secondary">Go to Shop</a>
+          <a href={withBasePath('/shop')} class="btn btn-secondary">Go to Shop</a>
         </div>
       </article>
       <article class="glass-panel quick-card">
         <h2>Need Help</h2>
         <p>Get support for login, purchases, and gameplay issues.</p>
         <div class="hero-actions">
-          <a href="/support" class="btn btn-secondary">Open Support</a>
+          <a href={withBasePath('/support')} class="btn btn-secondary">Open Support</a>
         </div>
       </article>
     </section>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { withBasePath } from '../lib/site-paths';
 ---
 
 <BaseLayout title="Contact" description="Contact Terapixel Games for support, partnerships, and studio inquiries.">
@@ -20,7 +21,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <section class="glass-panel text-panel">
       <h2>Need Faster Routing?</h2>
       <p>
-        Use the <a href="/support">Support page</a> for account, billing, or gameplay issue categories.
+        Use the <a href={withBasePath('/support')}>Support page</a> for account, billing, or gameplay issue categories.
       </p>
     </section>
   </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import GameCard from '../components/GameCard.astro';
 import games from '../data/games.json';
 import type { Game } from '../types';
+import { withBasePath } from '../lib/site-paths';
 
 const gameList = games as Game[];
 const playableGames = gameList.filter((game) => (game.embedUrl || game.fullScreenUrl) && !game.isComingSoon);
@@ -21,8 +22,8 @@ const featuredGames = playableGames.slice(0, 2);
         Pick a game, jump straight into the fun, and play until there's just time for one more run.
       </p>
       <div class="hero-actions">
-        <a href="/games" class="btn btn-primary">Play Games</a>
-        <a href="/shop" class="btn btn-secondary">Visit Shop</a>
+        <a href={withBasePath('/games')} class="btn btn-primary">Play Games</a>
+        <a href={withBasePath('/shop')} class="btn btn-secondary">Visit Shop</a>
       </div>
       <p class="hero-note">Quick to start, easy to return to, built for players who value clean experiences.</p>
       <div class="stat-row" aria-label="Platform highlights">

--- a/src/pages/shop.astro
+++ b/src/pages/shop.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { withBasePath } from '../lib/site-paths';
 
 const products = [
   {
@@ -48,7 +49,7 @@ const products = [
               {product.benefits.map((benefit) => <li>{benefit}</li>)}
             </ul>
             <div class="hero-actions">
-              <a href="/support" class="btn btn-primary">Purchase Support</a>
+              <a href={withBasePath('/support')} class="btn btn-primary">Purchase Support</a>
             </div>
           </article>
         ))


### PR DESCRIPTION
## Summary
- make internal nav/footer/page links base-aware so staging stays under /staging
- map game play links to base-aware URLs in cards and detail pages
- append build id query param to /play/* URLs to bust stale iframe/fullscreen cache
- set PUBLIC_TPX_BUILD_ID in staging/prod deploy workflows

## Validation
- npm.cmd run build -- --base /staging/