### PR TITLE
Sync H5 ad game builds

### DIFF
--- a/public/play/color-crunch/index.html
+++ b/public/play/color-crunch/index.html
@@ -96,7 +96,7 @@ body {
 window.COLOR_CRUNCH_PAYPAL_CLIENT_ID = "AbG4sfI0nBa9q1mz57fXTn2MCI9EGhNmc1y71c5Ba-ruYaZztTqhqfjmH2C8i7xSrRThBMpWV7yksija";
 </script>
 	<!-- arcadecore-h5-ads:start -->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=pub-8413230766502262" crossorigin="anonymous" data-ad-client="pub-8413230766502262"></script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8413230766502262" crossorigin="anonymous" data-ad-client="ca-pub-8413230766502262"></script>
 <script>
 window.adsbygoogle = window.adsbygoogle || [];
 window.adBreak = window.adConfig = function(o) { window.adsbygoogle.push(o); };

--- a/public/play/lumarush/index.html
+++ b/public/play/lumarush/index.html
@@ -94,7 +94,7 @@ body {
 <link rel="apple-touch-icon" href="index.apple-touch-icon.png"/>
 
 	<!-- arcadecore-h5-ads:start -->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=pub-8413230766502262" crossorigin="anonymous" data-ad-client="pub-8413230766502262"></script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8413230766502262" crossorigin="anonymous" data-ad-client="ca-pub-8413230766502262"></script>
 <script>
 window.adsbygoogle = window.adsbygoogle || [];
 window.adBreak = window.adConfig = function(o) { window.adsbygoogle.push(o); };

--- a/public/play/speedsolitaire/index.html
+++ b/public/play/speedsolitaire/index.html
@@ -94,7 +94,7 @@ body {
 <link rel="apple-touch-icon" href="index.apple-touch-icon.png"/>
 
 	<!-- arcadecore-h5-ads:start -->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=pub-8413230766502262" crossorigin="anonymous" data-ad-client="pub-8413230766502262"></script>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8413230766502262" crossorigin="anonymous" data-ad-client="ca-pub-8413230766502262"></script>
 <script>
 window.adsbygoogle = window.adsbygoogle || [];
 window.adBreak = window.adConfig = function(o) { window.adsbygoogle.push(o); };


### PR DESCRIPTION
## Summary
- Sync Color Crunch v0.0.37, LumaRush v0.0.39, and SpeedSolitaire v0.0.17 web exports into terapixel.games
- Use corrected H5 AdSense client tag ca-pub-8413230766502262 in each embedded game page
- Avoid the previous BOM-prefixed client value that prevented H5 ad loading

## Verification
- Verified all three release ZIPs contain client=ca-pub-8413230766502262
- Verified all three release ZIPs do not contain %EF%BB%BF or bare client=pub-8413230766502262
- npm ci
- npm run build