### PR TITLE
Sync fixed Racer web playback build

### DIFF
--- a/public/play/racer/index.html
+++ b/public/play/racer/index.html
@@ -111,7 +111,7 @@ body {
 
 		<script src="index.js"></script>
 		<script>
-const GODOT_CONFIG = {"args":[],"canvasResizePolicy":2,"emscriptenPoolSize":8,"ensureCrossOriginIsolationHeaders":true,"executable":"index","experimentalVK":false,"fileSizes":{"index.pck":42882736,"index.wasm":38034280},"focusCanvas":true,"gdextensionLibs":[],"godotPoolSize":4};
+const GODOT_CONFIG = {"args":[],"canvasResizePolicy":2,"emscriptenPoolSize":8,"ensureCrossOriginIsolationHeaders":true,"executable":"index","experimentalVK":false,"fileSizes":{"index.pck":70732264,"index.wasm":38034280},"focusCanvas":true,"gdextensionLibs":[],"godotPoolSize":4};
 const GODOT_THREADS_ENABLED = false;
 const engine = new Engine(GODOT_CONFIG);
 


### PR DESCRIPTION
## Summary
- Sync Racer web export from racer release v0.0.5.
- Includes the fixed playback export that restores required Nakama, gameplay scene, shader, and Kitchen track resources while keeping index.pck under GitHub's 100 MB hard limit.

## Verification
- npm.cmd run build
- git diff --check -- public/play/racer
- Racer repo CI passed for v0.0.5: Godot Unit + UAT, Godot Web Release + Pages, and Deploy Nakama To Cloud Run.

## Release
- https://github.com/Terapixel-Games/racer/releases/tag/v0.0.5