### PR TITLE
[codex] Keep page scrolling over game embeds

### DIFF
--- a/src/components/KeepPageWheelScroll.astro
+++ b/src/components/KeepPageWheelScroll.astro
@@ -1,0 +1,48 @@
+<script>
+  const attachedFrames = new WeakMap();
+
+  const forwardWheelToPage = (event) => {
+    if (!event.deltaY && !event.deltaX) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    window.scrollBy({
+      top: event.deltaY,
+      left: event.deltaX,
+      behavior: 'auto'
+    });
+  };
+
+  const attachWheelForwarding = (iframe) => {
+    const previous = attachedFrames.get(iframe);
+    if (previous) {
+      previous.window?.removeEventListener('wheel', forwardWheelToPage, true);
+      previous.document?.removeEventListener('wheel', forwardWheelToPage, true);
+    }
+
+    try {
+      const frameWindow = iframe.contentWindow;
+      const frameDocument = iframe.contentDocument;
+      if (!frameWindow || !frameDocument) return;
+
+      frameWindow.addEventListener('wheel', forwardWheelToPage, { capture: true, passive: false });
+      frameDocument.addEventListener('wheel', forwardWheelToPage, { capture: true, passive: false });
+      attachedFrames.set(iframe, { window: frameWindow, document: frameDocument });
+    } catch {
+      // Cross-origin frames cannot be wired; current Terapixel game embeds are same-origin.
+    }
+  };
+
+  const wireGameFrames = () => {
+    document.querySelectorAll('[data-page-wheel-scroll] iframe').forEach((iframe) => {
+      attachWheelForwarding(iframe);
+      iframe.addEventListener('load', () => attachWheelForwarding(iframe));
+    });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', wireGameFrames, { once: true });
+  } else {
+    wireGameFrames();
+  }
+</script>

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import KeepPageWheelScroll from '../components/KeepPageWheelScroll.astro';
 import games from '../data/games.json';
 import type { Game } from '../types';
 import { addBuildVersion, withBasePath } from '../lib/site-paths';
@@ -100,7 +101,7 @@ const faqJsonLd =
   {faqJsonLd && <script slot="head" type="application/ld+json" set:html={JSON.stringify(faqJsonLd)} />}
 
   <section class="play-shell is-game-first" data-accent={game.accent ?? 'signal'} aria-labelledby="game-title">
-    <div class:list={['play-frame-shell', isPortraitEmbed && 'is-portrait']}>
+    <div class:list={['play-frame-shell', isPortraitEmbed && 'is-portrait']} data-page-wheel-scroll>
       {
         showEmbed ? (
           <iframe
@@ -265,4 +266,6 @@ const faqJsonLd =
       )
     }
   </div>
+
+  <KeepPageWheelScroll />
 </BaseLayout>

--- a/src/pages/games.astro
+++ b/src/pages/games.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import GameCard from '../components/GameCard.astro';
+import KeepPageWheelScroll from '../components/KeepPageWheelScroll.astro';
 import games from '../data/games.json';
 import type { Game } from '../types';
 import { addBuildVersion, withBasePath } from '../lib/site-paths';
@@ -29,7 +30,7 @@ const isPrimaryPortrait = primaryGame.embedOrientation === 'portrait';
   enableAds={true}
 >
   <section class="play-shell is-game-first" data-accent={primaryGame.accent ?? 'signal'} aria-labelledby="games-heading">
-    <div class:list={['play-frame-shell', isPrimaryPortrait && 'is-portrait']}>
+    <div class:list={['play-frame-shell', isPrimaryPortrait && 'is-portrait']} data-page-wheel-scroll>
       {
         primaryEmbedUrl ? (
           <iframe
@@ -121,4 +122,6 @@ const isPrimaryPortrait = primaryGame.embedOrientation === 'portrait';
       </div>
     </section>
   </div>
+
+  <KeepPageWheelScroll />
 </BaseLayout>


### PR DESCRIPTION
## What changed
- Adds a small wheel-event bridge for same-origin game iframes.
- Applies it to game detail pages and the featured game on /games.
- Keeps mouse-wheel scrolling moving the site even when the pointer is over the embedded game.

## Why
The embedded game iframe could consume wheel input before the page could scroll, making it harder to reach the details and library sections from the full-screen game layout.

## Validation
- npm.cmd run build
- Browser-tested /color-crunch: wheel scrolling over the game iframe moves the parent page.
- Browser-tested /games: wheel scrolling over the featured iframe moves the parent page.