### PR TITLE
ci: use Node 22 for Astro 6 deploys

### DIFF
--- a/.github/workflows/deploy-edge-router.yml
+++ b/.github/workflows/deploy-edge-router.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install Wrangler
         run: npm install -g wrangler@4

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS build
+FROM node:22-alpine AS build
 WORKDIR /app
 
 COPY package.json package-lock.json ./


### PR DESCRIPTION
## Summary
- update staging deploy workflow to use Node 22 for Astro 6
- update edge router workflow Node setup to Node 22
- update production Docker build image to node:22-alpine

## Why
Astro 6 requires Node >=22.12.0. Staging failed on main because deploy-staging was still using Node 20.20.2; production would hit the same issue in the Docker build stage.

## Verification
- npm.cmd ci
- npm.cmd run build