### PR TITLE
sync: update LumaRush web build

### DIFF
--- a/public/play/lumarush/index.html
+++ b/public/play/lumarush/index.html
@@ -171,7 +171,7 @@ window.arcadecoreH5Ads = window.arcadecoreH5Ads || (function() {
 
 		<script src="index.js"></script>
 		<script>
-const GODOT_CONFIG = {"args":[],"canvasResizePolicy":2,"emscriptenPoolSize":8,"ensureCrossOriginIsolationHeaders":true,"executable":"index","experimentalVK":false,"fileSizes":{"index.pck":31112712,"index.wasm":38034280},"focusCanvas":true,"gdextensionLibs":[],"godotPoolSize":4};
+const GODOT_CONFIG = {"args":[],"canvasResizePolicy":2,"emscriptenPoolSize":8,"ensureCrossOriginIsolationHeaders":true,"executable":"index","experimentalVK":false,"fileSizes":{"index.pck":31790420,"index.wasm":38034280},"focusCanvas":true,"gdextensionLibs":[],"godotPoolSize":4};
 const GODOT_THREADS_ENABLED = false;
 const engine = new Engine(GODOT_CONFIG);
 


### PR DESCRIPTION
Deploys the LumaRush web export built from LumaRush commit f6569ca (Keep LumaRush score badge text contained).\n\nLocal verification:\n- Godot Web export completed with godot_console.exe --headless --export-release Web\n- Re-applied ArcadeCore H5 ads injection to public/play/lumarush/index.html\n- 
pm.cmd ci\n- 
pm.cmd run build\n\nNotes:\n- The web bundle changes are limited to public/play/lumarush/index.pck and the matching index.pck file size in index.html.