### PR TITLE
[codex] update LumaRush no-symbol web build

### DIFF
--- a/public/play/lumarush/index.html
+++ b/public/play/lumarush/index.html
@@ -171,7 +171,7 @@ window.arcadecoreH5Ads = window.arcadecoreH5Ads || (function() {
 
 		<script src="index.js"></script>
 		<script>
-const GODOT_CONFIG = {"args":[],"canvasResizePolicy":2,"emscriptenPoolSize":8,"ensureCrossOriginIsolationHeaders":true,"executable":"index","experimentalVK":false,"fileSizes":{"index.pck":31790420,"index.wasm":38034280},"focusCanvas":true,"gdextensionLibs":[],"godotPoolSize":4};
+const GODOT_CONFIG = {"args":[],"canvasResizePolicy":2,"emscriptenPoolSize":8,"ensureCrossOriginIsolationHeaders":true,"executable":"index","experimentalVK":false,"fileSizes":{"index.pck":31789316,"index.wasm":38034280},"focusCanvas":true,"gdextensionLibs":[],"godotPoolSize":4};
 const GODOT_THREADS_ENABLED = false;
 const engine = new Engine(GODOT_CONFIG);
 


### PR DESCRIPTION
﻿## Summary
- updates the hosted LumaRush Web build from source commit `8dde7a0`
- removes the tile symbol/glyph overlays from the website build
- preserves the H5 ad injection in `public/play/lumarush/index.html`

## Verification
- LumaRush source: `scripts/run-tests.ps1 -Suite unit -GodotBin C:\code\bin\godot_console.exe` passed: 143 tests, 0 failures
- LumaRush source: `scripts/run-tests.ps1 -Suite uat -GodotBin C:\code\bin\godot_console.exe` passed: 16 tests, 0 failures
- Godot Web export from clean worktree at `8dde7a0` produced `index.pck` size `31789316`
- `npm ci` completed; existing audit findings remain
- `npm run build` passed
- built `dist/play/lumarush/index.html` references `index.pck` size `31789316`
- H5 ad injection remains present in built output

## Notes
- First clean Godot export attempt crashed during import warmup; rerun succeeded and artifacts were verified before this commit.
- Godot still emits existing FreeType warnings during export.
