### PR TITLE
[codex] bust GlowPath loader image cache

### DIFF
--- a/public/play/glowpath/index.html
+++ b/public/play/glowpath/index.html
@@ -104,7 +104,7 @@ body {
 		</noscript>
 
 		<div id="status">
-			<img id="status-splash" class="show-image--true fullsize--true use-filter--true" src="index.png" alt="">
+			<img id="status-splash" class="show-image--true fullsize--true use-filter--true" src="index.png?v=91bb8f5974f3" alt="">
 			<progress id="status-progress"></progress>
 			<div id="status-notice"></div>
 		</div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1335,16 +1335,16 @@ body:has(.play-shell.is-game-first) .site-header {
 
 .portal-player-frame.is-portrait,
 .play-frame-shell.is-portrait {
-  max-width: min(100%, 620px);
-  justify-self: center;
+  max-width: none;
+  justify-self: stretch;
   width: 100%;
 }
 
 .portal-player-frame.is-portrait iframe,
 .play-frame-shell.is-portrait iframe {
-  width: min(100%, 520px);
-  left: 50%;
-  transform: translateX(-50%);
+  width: 100%;
+  left: 0;
+  transform: none;
 }
 
 .below-play {
@@ -1497,7 +1497,7 @@ body:has(.play-shell.is-game-first) .site-header {
 }
 
 .play-shell.is-game-first .play-frame-shell.is-portrait {
-  max-width: min(100%, 680px);
+  max-width: none;
 }
 
 .play-shell.is-game-first .play-title-row {


### PR DESCRIPTION
## What changed
- Adds a cache-busting query string to GlowPath's web loader image reference.
- Removes the shared portrait iframe width caps so GlowPath and Worm Breaker fill the available play frame instead of being forced into a narrow vertical cabinet.

## Validation
- Confirmed production `index.png` was a Cloudflare cache HIT with old content length before this fix.
- Ran `cmd /c npm run build` in a clean site worktree.
- Confirmed generated CSS no longer contains the `680px` portrait frame cap or `520px` portrait iframe cap.

## Source repo note
- Added `scripts/fix-web-loader-cache.ps1` to `Terapixel-Games/GlowPath` and pushed `6afe073` so future exports can repeat the loader cache-busting post-process.
