### PR TITLE
Bust cached Worm Breaker and LumaRush splash assets

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,5 @@
+/play/lumarush/*
+  Cache-Control: no-cache, must-revalidate
+
+/play/worm-breaker/*
+  Cache-Control: no-cache, must-revalidate

--- a/public/play/lumarush/index.html
+++ b/public/play/lumarush/index.html
@@ -104,7 +104,7 @@ body {
 		</noscript>
 
 		<div id="status">
-			<img id="status-splash" class="show-image--true fullsize--true use-filter--true" src="index.png" alt="">
+			<img id="status-splash" class="show-image--true fullsize--true use-filter--true" src="index.png?v=v0.0.53-71bb381" alt="">
 			<progress id="status-progress"></progress>
 			<div id="status-notice"></div>
 		</div>
@@ -217,4 +217,3 @@ const engine = new Engine(GODOT_CONFIG);
 		</script>
 	</body>
 </html>
-

--- a/public/play/worm-breaker/index.html
+++ b/public/play/worm-breaker/index.html
@@ -104,7 +104,7 @@ body {
 		</noscript>
 
 		<div id="status">
-			<img id="status-splash" class="show-image--true fullsize--true use-filter--true" src="index.png" alt="">
+			<img id="status-splash" class="show-image--true fullsize--true use-filter--true" src="index.png?v=v0.0.5-238702e" alt="">
 			<progress id="status-progress"></progress>
 			<div id="status-notice"></div>
 		</div>
@@ -217,4 +217,3 @@ const engine = new Engine(GODOT_CONFIG);
 		</script>
 	</body>
 </html>
-


### PR DESCRIPTION
## Summary
- Add release-specific cache busters to the Worm Breaker and LumaRush Godot loading splash image URLs
- Add Cloudflare Pages headers for those play paths so browser caches revalidate game assets

## Verification
- npm.cmd ci
- npm.cmd run build
- Verified dist/play/worm-breaker/index.html includes index.png?v=v0.0.5-238702e
- Verified dist/play/lumarush/index.html includes index.png?v=v0.0.53-71bb381
- Verified dist/_headers includes revalidation rules for /play/worm-breaker/* and /play/lumarush/*